### PR TITLE
Fix docstring in visualize

### DIFF
--- a/utils/visualize.py
+++ b/utils/visualize.py
@@ -58,11 +58,12 @@ def plot_episode_rewards(rewards: Dict[str, List[float]],
 def plot_evaluation_results(results: Dict[str, float], 
                           output_path: Optional[str] = None) -> None:
     """Plot evaluation results.
-    
+
     Args:
         results: Dictionary of evaluation metrics
         output_path: Optional path to save the plot
-    """n    plt.figure(figsize=(10, 6))
+    """
+    plt.figure(figsize=(10, 6))
     
     # Filter and sort metrics for plotting
     metrics = {k: v for k, v in results.items() if not k.startswith('num_')}


### PR DESCRIPTION
## Summary
- clean up stray character in `plot_evaluation_results` docstring

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858400c405c832686095d15aa138395