### PR TITLE
Update evaluation command and fix README license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [Stable Baselines3](https://github.com/DLR-RM/stable-baselines3) for the RL algorithms
 - [Gymnasium](https://gymnasium.farama.org/) for the environment interface
 - [PyTorch](https://pytorch.org/) for deep learning
-- Run evaluation: `python -m src.evaluate`
+- Run evaluation: `python evaluate.py`
 - Start web interface: `streamlit run streamlit_app/app.py`
-
-## License
-
-This project is licensed under the MIT License - see the LICENSE file for details.


### PR DESCRIPTION
## Summary
- update evaluation command in README
- remove duplicate license section in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858401483f08326b02f2605317769c7